### PR TITLE
Resolve " angles/angles.h" wrong path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rviz_default_plugins REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(angles REQUIRED)
 
 find_package(Qt5 COMPONENTS Core Gui Network Concurrent Widgets REQUIRED)
 
@@ -50,8 +51,8 @@ if(BUILD_TESTING)
   target_include_directories(test_field PRIVATE src)
 endif()
 
-ament_target_dependencies(${PROJECT_NAME} rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs tf2_ros)
-ament_export_dependencies(rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs tf2_ros)
+ament_target_dependencies(${PROJECT_NAME} rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs tf2_ros angles)
+ament_export_dependencies(rclcpp pluginlib rviz_common rviz_default_plugins sensor_msgs tf2_ros angles)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 


### PR DESCRIPTION
There seems to have been an issue where cMake couldnt find the angles/angles.h library while compiling. I resolved the issues by adding angles to the required Libraries in the CMakeLists.txt. Now the Plugin builds and works fine.
To spare other people the effort of fixing this themselves, consider this pull request.